### PR TITLE
Añadir rutas y vistas para Future e Isolate en la aplicación Flutter

### DIFF
--- a/lib/routes/app_router.dart
+++ b/lib/routes/app_router.dart
@@ -3,7 +3,9 @@ import 'package:parqueadero_2025_g2/views/ciclo_vida/ciclo_vida_screen.dart';
 import 'package:parqueadero_2025_g2/views/paso_parametros/detalle_screen.dart';
 import 'package:parqueadero_2025_g2/views/paso_parametros/paso_parametros_screen.dart';
 
+import '../views/future/future_view.dart';
 import '../views/home/home_screen.dart';
+import '../views/isolate/isolate_view.dart';
 
 final GoRouter appRouter = GoRouter(
   routes: [
@@ -35,6 +37,18 @@ final GoRouter appRouter = GoRouter(
     GoRoute(
       path: '/ciclo_vida',
       builder: (context, state) => const CicloVidaScreen(),
+    ),
+    //!Ruta para FUTURE
+    GoRoute(
+      path: '/future',
+      name: 'future',
+      builder: (context, state) => const FutureView(),
+    ),
+    //!Ruta para ISOLATE
+    GoRoute(
+      path: '/isolate',
+      name: 'isolate',
+      builder: (context, state) => const IsolateView(),
     ),
   ],
 );

--- a/lib/views/future/future_view.dart
+++ b/lib/views/future/future_view.dart
@@ -1,0 +1,103 @@
+import 'dart:async';
+import 'package:flutter/material.dart';
+
+import '../../widgets/base_view.dart';
+
+class FutureView extends StatefulWidget {
+  const FutureView({super.key});
+
+  @override
+  State<FutureView> createState() => _FutureViewState();
+}
+
+class _FutureViewState extends State<FutureView> {
+  List<String> _nombres = []; // declarar una lista.
+
+  @override
+  // !inicializa el estado
+  // *llama a la funcion obtenerDatos() para cargar los datos al iniciar
+  void initState() {
+    super.initState();
+    obtenerDatos(); // carga al iniciar
+  }
+
+  // !Funcion que simula una carga de datos
+  //*espera 5 segundos antes de cargar los datos, esto simula una carga de datos.
+  Future<List<String>> cargarNombres() async {
+    //future.delayed() simula una carga de datos
+    await Future.delayed(const Duration(seconds: 5));
+    return [
+      'Juan',
+      'Pedro',
+      'Luis',
+      'Ana',
+      'Maria',
+      'Jose',
+      'Carlos',
+      'Sofia',
+      'Laura',
+      'Fernando',
+      'Ricardo',
+      'Diana',
+      'Elena',
+      'Miguel',
+      'Rosa',
+      'Luz',
+      'Carmen',
+      'Pablo',
+      'Jorge',
+      'Roberto',
+    ];
+  }
+
+  // !Funcion que obtiene los datos
+  // *carga los datos y los asigna a la lista _nombres
+  Future<void> obtenerDatos() async {
+    final datos =
+        await cargarNombres(); // await porque cargarNombres es una funcion asincrona
+
+    //!mounted es una propiedad de State que indica si el widget está montado en el árbol de widgets
+    //mounted es true si el widget está montado en el árbol de widgets
+    //mounted es false si el widget no está montado en el árbol de widgets
+
+    if (!mounted) return; //funciones de flecha
+    setState(() {
+      // se encarga de redibujar la pantalla
+      _nombres = datos;
+    });
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return BaseView(
+      title: 'Futures - GridView',
+      body:
+          //*si la lista esta vacia muestra un CircularProgressIndicator
+          _nombres.isEmpty
+          ? const Center(child: CircularProgressIndicator())
+          : Padding(
+              padding: const EdgeInsets.all(10.0),
+              child: GridView.builder(
+                itemCount: _nombres.length,
+                gridDelegate: const SliverGridDelegateWithFixedCrossAxisCount(
+                  crossAxisCount: 2, // columnas
+                  mainAxisSpacing: 10,
+                  crossAxisSpacing: 10,
+                  childAspectRatio: 2,
+                ),
+                itemBuilder: (context, index) {
+                  return Card(
+                    color: const Color.fromARGB(255, 87, 194, 180),
+                    child: Center(
+                      child: Text(
+                        _nombres[index], // muestra el nombre en la posicion index, index es el indice del item en la lista
+                        style: const TextStyle(fontSize: 18),
+                      ),
+                    ),
+                  );
+                },
+              ),
+            ),
+    );
+  }
+}

--- a/lib/views/isolate/isolate_view.dart
+++ b/lib/views/isolate/isolate_view.dart
@@ -1,0 +1,101 @@
+import 'dart:async';
+import 'dart:isolate';
+import 'package:flutter/foundation.dart';
+import 'package:flutter/material.dart';
+import '../../widgets/base_view.dart';
+
+class IsolateView extends StatefulWidget {
+  const IsolateView({super.key});
+
+  @override
+  State<IsolateView> createState() => _IsolateViewState();
+}
+
+class _IsolateViewState extends State<IsolateView> {
+  String resultado = "Presiona el botón para ejecutar";
+
+  //!Función que ejecuta la tarea pesada en un Isolate
+  //es Future<void> porque se ejecuta en un hilo secundario
+  //Future se usa para ejecutar tareas asincronas
+  Future<void> isolateTask() async {
+    final receivePort = ReceivePort(); // Buzón para recibir datos
+
+    // Lanza un nuevo Isolate y le pasa el canal de comunicación principal
+    await Isolate.spawn(
+      //isolate.comp
+      _simulacionTareaPesada,
+      receivePort.sendPort,
+    ); //es await porque es una operación asincrona y puede tardar en completarse
+
+    // Espera a recibir el sendPort del nuevo isolate
+    final sendPort = await receivePort.first as SendPort;
+
+    // Crea un canal para recibir la respuesta
+    final response = ReceivePort();
+
+    // Envía un mensaje al isolate: datos + cómo responder (replyPort)
+    sendPort.send(["Hola desde el hilo principal", response.sendPort]);
+
+    // Espera la respuesta del isolate
+    final result = await response.first as String;
+
+    //*Actualiza la UI con el resultado
+    //mounted es una propiedad de State que indica si el widget está montado en el árbol de widgets
+    //mounted es true si el widget está montado en el árbol de widgets
+    //mounted es false si el widget no está montado en el árbol de widgets
+    if (!mounted) return;
+    setState(() {
+      resultado = result;
+    });
+  }
+
+  //!simulacionTareaPesada es una función que simula una tarea pesada en un Isolate
+  // *SendPort es un canal de comunicación unidireccional que se puede usar para enviar mensajes a un Isolate.
+  static void _simulacionTareaPesada(SendPort sendPort) async {
+    final port = ReceivePort(); // Buzón interno del isolate
+    sendPort.send(port.sendPort); // Se lo enviamos al hilo principal
+    // Espera a recibir mensajes
+    await for (final message in port) {
+      final data = message[0] as String;
+      final puertoReceptor = message[1] as SendPort; // Canal para responder
+
+      int counter = 0;
+      for (int i = 1; i <= 10000; i++) {
+        counter += i;
+        if (kDebugMode) {
+          print("Isolate contando: $i");
+        }
+      }
+
+      puertoReceptor.send(
+        "Tarea completada. Suma : $counter.\nMensaje recibido: '$data'",
+      );
+      port.close(); // Cierra el puerto
+      Isolate.exit(); // Finaliza el Isolate.
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return BaseView(
+      title: "Demo de Isolate",
+      body: Center(
+        child: Padding(
+          //Padding es un widget que añade espacio alrededor de su hijo.
+          padding: const EdgeInsets.all(16.0),
+          child: Column(
+            mainAxisAlignment: MainAxisAlignment.center,
+            children: [
+              Text(resultado, textAlign: TextAlign.center),
+              const SizedBox(height: 20),
+              ElevatedButton(
+                onPressed: isolateTask,
+                child: const Text("Ejecutar tarea en segundo plano"),
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/lib/widgets/custom_drawer.dart
+++ b/lib/widgets/custom_drawer.dart
@@ -78,6 +78,22 @@ class CustomDrawer extends StatelessWidget {
               context.go('/ciclo_vida');
             },
           ),
+          //!FUTURE
+          ListTile(
+            leading: const Icon(Icons.input),
+            title: const Text('Future'),
+            onTap: () {
+              context.go('/future');
+            },
+          ),
+          //!ISOLATE
+          ListTile(
+            leading: const Icon(Icons.input),
+            title: const Text('Isolate'),
+            onTap: () {
+              context.go('/isolate');
+            },
+          ),
         ],
       ),
     );


### PR DESCRIPTION
This pull request adds new functionality to the application by introducing two new screens: one demonstrating the use of Dart `Future` for asynchronous operations and another showcasing the use of Dart `Isolate` for running tasks in a separate thread. The router and navigation drawer have been updated to support these new screens.

**New Feature Screens**

* Added `FutureView` screen that simulates asynchronous data loading using `Future.delayed`, displaying a grid of names after a delay. (`lib/views/future/future_view.dart`)
* Added `IsolateView` screen that demonstrates running a heavy computation in a background isolate, updating the UI with the result upon completion. (`lib/views/isolate/isolate_view.dart`)

**Routing and Navigation**

* Registered new routes `/future` and `/isolate` in the app router to enable navigation to the new screens. (`lib/routes/app_router.dart`) [[1]](diffhunk://#diff-368bd24ca5a05e40faadb5cf62a7623f43cd0569b35270926b69e15ff3579ec5R6-R8) [[2]](diffhunk://#diff-368bd24ca5a05e40faadb5cf62a7623f43cd0569b35270926b69e15ff3579ec5R41-R52)
* Updated the navigation drawer to include menu items for the new `Future` and `Isolate` screens, allowing users to access them easily from the UI. (`lib/widgets/custom_drawer.dart`)